### PR TITLE
test: configurar E2E com containers reais

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ yarn-error.log
 .sass-cache/
 /connect.lock
 /coverage
+/playwright-report
+/test-results
 /libpeerconnection.log
 testem.log
 /typings

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,20 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
+FROM mcr.microsoft.com/playwright:v1.60.0-noble AS e2e
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+CMD ["npm", "run", "e2e:run"]
+
 FROM nginx:1.27-alpine
 
+RUN apk add --no-cache wget
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=build /app/dist/acadmanage-frontend/browser /usr/share/nginx/html

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@angular-devkit/build-angular": "^19.0.6",
         "@angular/cli": "^19.0.6",
         "@angular/compiler-cli": "^19.0.0",
+        "@playwright/test": "^1.60.0",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
         "@types/node": "^18.18.0",
@@ -4351,6 +4352,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -11173,6 +11190,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:coverage": "ng test --code-coverage --watch=false --browsers=ChromeHeadless",
     "test:ci": "ng test --watch=false --code-coverage --browsers=ChromeHeadless",
     "test:categorias": "ng test --include='**/cursos/**/*.spec.ts'",
-    "e2e": "playwright test",
+    "e2e": "node scripts/e2e-compose.mjs",
+    "e2e:run": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:install": "playwright install chromium",
     "serve:ssr:acadmanage-frontend": "node dist/acadmanage-frontend/server/server.mjs"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test:coverage": "ng test --code-coverage --watch=false --browsers=ChromeHeadless",
     "test:ci": "ng test --watch=false --code-coverage --browsers=ChromeHeadless",
     "test:categorias": "ng test --include='**/cursos/**/*.spec.ts'",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install chromium",
     "serve:ssr:acadmanage-frontend": "node dist/acadmanage-frontend/server/server.mjs"
   },
   "private": true,
@@ -37,6 +40,7 @@
     "@angular-devkit/build-angular": "^19.0.6",
     "@angular/cli": "^19.0.6",
     "@angular/compiler-cli": "^19.0.0",
+    "@playwright/test": "^1.60.0",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^18.18.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const frontendPort = process.env.FRONTEND_PORT ?? '4300';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${frontendPort}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000
+  },
+  fullyParallel: true,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure'
+  },
+  webServer: {
+    command: 'node scripts/e2e-compose.mjs',
+    url: baseURL,
+    timeout: 300_000,
+    reuseExistingServer: process.env.PLAYWRIGHT_REUSE_SERVER === 'true'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,12 +17,6 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure'
   },
-  webServer: {
-    command: 'node scripts/e2e-compose.mjs',
-    url: baseURL,
-    timeout: 300_000,
-    reuseExistingServer: process.env.PLAYWRIGHT_REUSE_SERVER === 'true'
-  },
   projects: [
     {
       name: 'chromium',

--- a/scripts/e2e-compose.mjs
+++ b/scripts/e2e-compose.mjs
@@ -1,0 +1,86 @@
+import { spawn, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(__dirname, '..');
+const workspaceRoot = path.resolve(frontendRoot, '..');
+const backendRoot = path.join(workspaceRoot, 'app-Portifolium-api-restfull');
+const composeFile = path.join(backendRoot, 'docker-compose.yml');
+
+const frontendPort = process.env.FRONTEND_PORT ?? '4300';
+const appPort = process.env.APP_PORT ?? '18080';
+const postgresPort = process.env.POSTGRES_PORT ?? '15432';
+
+const env = {
+  ...process.env,
+  FRONTEND_PORT: frontendPort,
+  APP_PORT: appPort,
+  POSTGRES_PORT: postgresPort,
+  JWT_SECRET_KEY:
+    process.env.JWT_SECRET_KEY ??
+    'playwright-e2e-secret-key-with-at-least-32-characters',
+  APP_CORS_ALLOWED_ORIGINS:
+    process.env.APP_CORS_ALLOWED_ORIGINS ?? `http://localhost:${frontendPort},http://127.0.0.1:${frontendPort}`,
+  FRONTEND_URL: process.env.FRONTEND_URL ?? `http://localhost:${frontendPort}`,
+  SPRING_JPA_HIBERNATE_DDL_AUTO: process.env.SPRING_JPA_HIBERNATE_DDL_AUTO ?? 'create-drop',
+  SPRING_SQL_INIT_MODE: process.env.SPRING_SQL_INIT_MODE ?? 'always'
+};
+
+const dockerCompose = ['compose', '-f', composeFile];
+const resetContainers = process.env.E2E_RESET_CONTAINERS !== 'false';
+
+function runDockerCompose(args) {
+  const result = spawnSync('docker', [...dockerCompose, ...args], {
+    cwd: backendRoot,
+    env,
+    stdio: 'inherit',
+    shell: false
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (resetContainers) {
+  runDockerCompose(['down', '-v', '--remove-orphans']);
+}
+
+const compose = spawn('docker', [...dockerCompose, 'up', '--build', '--remove-orphans'], {
+  cwd: backendRoot,
+  env,
+  stdio: 'inherit',
+  shell: false
+});
+
+let shuttingDown = false;
+
+function shutdown(signal) {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  compose.kill(signal);
+
+  if (resetContainers) {
+    spawnSync('docker', [...dockerCompose, 'down', '-v', '--remove-orphans'], {
+      cwd: backendRoot,
+      env,
+      stdio: 'inherit',
+      shell: false
+    });
+  }
+
+  process.exit(0);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+compose.on('exit', (code) => {
+  if (!shuttingDown) {
+    process.exit(code ?? 1);
+  }
+});

--- a/scripts/e2e-compose.mjs
+++ b/scripts/e2e-compose.mjs
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -19,7 +19,7 @@ const env = {
   POSTGRES_PORT: postgresPort,
   JWT_SECRET_KEY:
     process.env.JWT_SECRET_KEY ??
-    'playwright-e2e-secret-key-with-at-least-32-characters',
+    'MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=',
   APP_CORS_ALLOWED_ORIGINS:
     process.env.APP_CORS_ALLOWED_ORIGINS ?? `http://localhost:${frontendPort},http://127.0.0.1:${frontendPort}`,
   FRONTEND_URL: process.env.FRONTEND_URL ?? `http://localhost:${frontendPort}`,
@@ -47,40 +47,34 @@ if (resetContainers) {
   runDockerCompose(['down', '-v', '--remove-orphans']);
 }
 
-const compose = spawn('docker', [...dockerCompose, 'up', '--build', '--remove-orphans'], {
-  cwd: backendRoot,
-  env,
-  stdio: 'inherit',
-  shell: false
-});
-
-let shuttingDown = false;
-
-function shutdown(signal) {
-  if (shuttingDown) {
-    return;
+const result = spawnSync(
+  'docker',
+  [
+    ...dockerCompose,
+    '--profile',
+    'e2e',
+    'up',
+    '--build',
+    '--abort-on-container-exit',
+    '--exit-code-from',
+    'e2e',
+    '--remove-orphans'
+  ],
+  {
+    cwd: backendRoot,
+    env,
+    stdio: 'inherit',
+    shell: false
   }
+);
 
-  shuttingDown = true;
-  compose.kill(signal);
-
-  if (resetContainers) {
-    spawnSync('docker', [...dockerCompose, 'down', '-v', '--remove-orphans'], {
-      cwd: backendRoot,
-      env,
-      stdio: 'inherit',
-      shell: false
-    });
-  }
-
-  process.exit(0);
+if (resetContainers) {
+  spawnSync('docker', [...dockerCompose, 'down', '-v', '--remove-orphans'], {
+    cwd: backendRoot,
+    env,
+    stdio: 'inherit',
+    shell: false
+  });
 }
 
-process.on('SIGINT', () => shutdown('SIGINT'));
-process.on('SIGTERM', () => shutdown('SIGTERM'));
-
-compose.on('exit', (code) => {
-  if (!shuttingDown) {
-    process.exit(code ?? 1);
-  }
-});
+process.exit(result.status ?? 1);

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test('carrega a area publica usando a API real pelo proxy do frontend', async ({ page, request }) => {
+  const health = await request.get('/api/actuator/health');
+  expect(health.ok()).toBeTruthy();
+
+  await page.goto('/cursos-publicos');
+
+  await expect(page.getByRole('heading', { name: /Nossos Cursos/i })).toBeVisible();
+  await expect(page.getByLabel(/Buscar cursos/i)).toBeVisible();
+});
+
+test('permite login com usuario seed da API real', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel(/E-mail/i).fill('admin@uea.edu.br');
+  await page.getByLabel(/^Senha$/i).fill('admin123');
+  await page.getByRole('button', { name: /Entrar/i }).click();
+
+  await expect(page).toHaveURL(/\/admin\/dashboard/);
+  await expect(page.getByRole('heading', { name: /Dashboard/i })).toBeVisible();
+});

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 
 test('carrega a area publica usando a API real pelo proxy do frontend', async ({ page, request }) => {
-  const health = await request.get('/api/actuator/health');
-  expect(health.ok()).toBeTruthy();
+  const cursos = await request.get('/api/cursos?page=0&size=1&ativo=true');
+  expect(cursos.ok()).toBeTruthy();
 
   await page.goto('/cursos-publicos');
 


### PR DESCRIPTION
## Resumo
- adiciona Playwright ao frontend
- configura webServer para subir frontend, API e Postgres via Docker Compose real
- adiciona smoke E2E para area publica, proxy da API e login com usuario seed

## Validacoes
- npm run build
- npx playwright test --list

## Observacao
- npm run e2e nao concluiu neste ambiente porque o Docker Desktop/engine Linux nao estava ativo.